### PR TITLE
Fixes checkout in publish nuget workflow.

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -11,9 +11,7 @@ jobs:
     
     steps:
       - name: Pull ${{ github.ref_name }}
-        run: |
-          git clone https://github.com/ThickPropheT/Reg.Roup.git
-          git checkout ${{ github.ref_name }}
+        run: git clone --branch ${{ github.ref_name }} github. https://github.com/ThickPropheT/Reg.Roup.git
     
       - name: Pack
         run: dotnet pack ./Reg.Roup


### PR DESCRIPTION
**Don't merge this**
instead, **CAREFULLY** roll back last 2 merges that went straight into main, then cherry pick them back into a feature branch.
